### PR TITLE
Fix segfault when XDG_CONFIG_HOME is defined

### DIFF
--- a/main.c
+++ b/main.c
@@ -130,8 +130,10 @@ static gboolean get_layout_path()
     {
         fprintf(stderr, "Failed to allocate memory\n");
     }
-    
-    char *config_path = getenv("XDG_CONFIG_HOME");
+
+    char *config_path = malloc(default_size * sizeof(char));
+    char *xdg_config_home = getenv("XDG_CONFIG_HOME");
+    strcpy(config_path, xdg_config_home);
     if (!config_path)
     {
         config_path = getenv("HOME");
@@ -193,8 +195,10 @@ static gboolean get_css_path()
     {
         fprintf(stderr, "Failed to allocate memory\n");
     }
-    
-    char *config_path = getenv("XDG_CONFIG_HOME");
+
+    char *config_path = malloc(default_size * sizeof(char));
+    char *xdg_config_home = getenv("XDG_CONFIG_HOME");
+    strcpy(config_path, xdg_config_home);
     if (!config_path)
     {
         config_path = getenv("HOME");


### PR DESCRIPTION
Relevant backtrace:
```
Program terminated with signal SIGABRT, Aborted.
#0  0x00007f27ef505f25 in raise () from /usr/lib/libc.so.6
[Current thread is 1 (Thread 0x7f27ee232000 (LWP 168523))]
(gdb) bt full
#0  0x00007f27ef505f25 in raise () at /usr/lib/libc.so.6
#1  0x00007f27ef4ef897 in abort () at /usr/lib/libc.so.6
#2  0x00007f27ef549258 in __libc_message () at /usr/lib/libc.so.6
#3  0x00007f27ef55077a in  () at /usr/lib/libc.so.6
#4  0x00007f27ef55214c in _int_free () at /usr/lib/libc.so.6
#5  0x000055b03e1bb6c9 in get_layout_path () at ../wlogout/main.c:157
        buf = 0x55b04025a120 "/home/ammgws/.config/wlogout/layout"
        config_path = 0x7ffcafacbebd "/home/ammgws/.config"
        n = 37
        inptr = <optimized out>
#6  0x000055b03e1bb6c9 in main (argc=<optimized out>, argv=<optimized out>) at ../wlogout/main.c:510
        i
```