### PR TITLE
Use terminate-session instead of terminate-user by default

### DIFF
--- a/layout
+++ b/layout
@@ -12,7 +12,7 @@
 }
 {
     "label" : "logout",
-    "action" : "loginctl terminate-user $USER",
+    "action" : "loginctl terminate-session $XDG_SESSION_ID",
     "text" : "Logout",
     "keybind" : "e"
 }


### PR DESCRIPTION
This will make it terminate only your current session instead of all sessions of the current user.