### PR TITLE
Use TOP Layer.

### DIFF
--- a/main.c
+++ b/main.c
@@ -282,7 +282,7 @@ static GtkWidget *get_window()
     else {
         #ifdef LAYERSHELL
         gtk_layer_init_for_window (window);
-        gtk_layer_set_layer (window, GTK_LAYER_SHELL_LAYER_OVERLAY);
+        gtk_layer_set_layer (window, GTK_LAYER_SHELL_LAYER_TOP);
         gtk_layer_set_exclusive_zone (window, exclusive_level);
         gtk_layer_set_keyboard_interactivity (window, TRUE);
 


### PR DESCRIPTION
The OVERLAY layer is used by lock screens and notifications.
Wlogout can appear over lock screens which may be a security issue.