### PR TITLE
Recognize the -C option as an alias of --css

### DIFF
--- a/main.c
+++ b/main.c
@@ -81,7 +81,7 @@ static gboolean process_args(int argc, char *argv[])
     while (TRUE)
     {
         int option_index = 0;
-        c = getopt_long(argc, argv, "hl:vc:m:b:T:R:L:B:r:c:p:",
+        c = getopt_long(argc, argv, "hl:vc:m:b:T:R:L:B:r:c:p:C:",
                 long_options, &option_index);
         if (c == -1)
         {


### PR DESCRIPTION
Currently, `wlogout --help` specifies `-C` as an alias of `--css` but then exits with
```bash
$ nix-shell -p wlogout --run "wlogout -C ~/.dots/home/config/display/wlogout/style.css"
wlogout: invalid option -- 'C'﻿
```
This changes the option string passed to `getopt_long` to recognize `-C` as an alias of `--css`.
