### PR TITLE
`scdoc` requires tabs

### DIFF
--- a/man/wlogout.1.scd
+++ b/man/wlogout.1.scd
@@ -50,7 +50,7 @@ wlogout - A Wayland logout menu
 	Takes either layer-shell or xdg. The layer-shell allows transparency effects; however, only a few compositors correctly support it. The xdg protocol will work on almost all compositors, but does not allow for transparency.
 
 *-s, --show-binds*
-    Will show the keybinds of a button by inserting the key needed to activate the button next to its label.
+	Will show the keybinds of a button by inserting the key needed to activate the button next to its label.
 
 # DESCRIPTION
 


### PR DESCRIPTION
```
[1/4] Generating wlogout.1 with a custom command
FAILED: wlogout.1
/nix/store/5l50g7kzj7v0rdhshld1vx46rf2k5lf9-bash-5.2p26/bin/sh -c '/nix/store/bww2fq4c4h0fj9lvdb20wx4mw39jac2m-scdoc-1.11.2-unstable-2023-03-08/bin/scdoc < ../man/wlogout.1.scd > wlogout.1'
Error at 53:1: Tabs are required for indentation
```