### PR TITLE
standardize use of loginctl in default config

### DIFF
--- a/layout
+++ b/layout
@@ -6,7 +6,7 @@
 }
 {
     "label" : "hibernate",
-    "action" : "systemctl hibernate",
+    "action" : "loginctl hibernate",
     "text" : "Hibernate",
     "keybind" : "h"
 }
@@ -18,19 +18,19 @@
 }
 {
     "label" : "shutdown",
-    "action" : "systemctl poweroff",
+    "action" : "loginctl poweroff",
     "text" : "Shutdown",
     "keybind" : "s"
 }
 {
     "label" : "suspend",
-    "action" : "systemctl suspend",
+    "action" : "loginctl suspend",
     "text" : "Suspend",
     "keybind" : "u"
 }
 {
     "label" : "reboot",
-    "action" : "systemctl reboot",
+    "action" : "loginctl reboot",
     "text" : "Reboot",
     "keybind" : "r"
 }


### PR DESCRIPTION
This commit standardizes the use of `loginctl` in favor of `systemctl` in the default configuration file.  Besides being good practice, this also allows the default configuration to work when [elogind](https://github.com/elogind/elogind) is used, which contains the loginctl command but not the systemctl command.