### PR TITLE
Don’t fuck with null-pointers

### DIFF
--- a/main.c
+++ b/main.c
@@ -587,7 +587,7 @@ static void load_buttons(GtkContainer *container)
     {
         for (int j = 0; j < num_col; j++)
         {
-            if (show_bind)
+            if (buttons[count].text && show_bind)
             {
                 strcat(buttons[count].text, "[");
                 strcat(buttons[count].text, (char *) &buttons[count].bind);


### PR DESCRIPTION
If you have 5 buttons, you end up with the following layout where ‘X’ is
a button with a label and ‘O’ is a filler button that does nothing.
With this layout if you pass the -s option the program iterates over
each slot and calls strcat() on the label, but crucially it does *not*
ignore the ‘O’ slot resulting in a segmentation fault.

```
┌───┬───┬───┐
│ X │ X │ X │
│───┼───┼───│
│ X │ X │ O │
└───┴───┴───┘
```