### PR TITLE
fix: width and height incorrectly assigned

### DIFF
--- a/main.c
+++ b/main.c
@@ -442,7 +442,10 @@ static gboolean get_buttons(FILE *json)
                 }
                 else
                 {
-                    buttons[num_buttons - 1].yalign = buffer[tok[i].start];
+                    char height[tok[i].size + 1];
+                    get_substring(height, tok[i].start, tok[i].end, buffer);
+
+                    buttons[num_buttons - 1].yalign = atof(height);
                 }
             }
             else if (strcmp(tmp, "width") == 0)
@@ -454,7 +457,10 @@ static gboolean get_buttons(FILE *json)
                 }
                 else
                 {
-                    buttons[num_buttons - 1].xalign = buffer[tok[i].start];
+                    char width[tok[i].size + 1];
+                    get_substring(width, tok[i].start, tok[i].end, buffer);
+
+                    buttons[num_buttons - 1].xalign = atof(width);
                 }
             }
             else if (strcmp(tmp, "circular") == 0)


### PR DESCRIPTION
fixes #58
width and height were being assigned to the ascii value of the first character of the token
which resulted in having the value being set to either 48.0 or 49.0 when we wanted a value between 0.0 and 1.0